### PR TITLE
fix(apiRequest): use url-encoded requestData as request body

### DIFF
--- a/nodes/KlickTipp/transport/index.ts
+++ b/nodes/KlickTipp/transport/index.ts
@@ -48,42 +48,36 @@ export async function apiRequest(
 	verifySSL: boolean = true,
 ) {
 	query = query || {};
+	const isForm = (method === 'POST' || method === 'PUT') && Object.keys(body).length > 0;
+	const requestBody = isForm ? toQueryString(body) : body;
 
 	// Build headers
 	const headers: IDataObject = {
-		'Content-Type': 'application/x-www-form-urlencoded',
 		...defaultHeaders,
+		...(isForm && {
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'Content-Length': Buffer.byteLength(requestBody as string).toString(),
+		}),
 	};
 
-	// Encode data if necessary for POST/PUT using the custom function
-	let requestData: string | undefined;
-	if (method === 'POST' || method === 'PUT') {
-		requestData = toQueryString(body);
-		headers['Content-Length'] = Buffer.byteLength(requestData).toString();
-	}
-
-	const options: IRequestOptions = {
+	const requestOptions: IRequestOptions = {
 		headers,
 		method,
-		body,
+		body: requestBody,
 		qs: query,
 		uri: uri || `${BASE_URL}/${endpoint}`,
 		useQuerystring: false,
 		json: true,
-		...option,
 		rejectUnauthorized: verifySSL,
+		...option,
 	};
-
-	if (Object.keys(body).length === 0) {
-		delete options.body;
-	}
 
 	try {
 		// Perform the main API request
 		return await this.helpers.requestWithAuthentication.call(
 			this,
 			KLICKTIPP_API_CREDENTIAL_NAME,
-			options,
+			requestOptions,
 		);
 	} finally {
 		// Perform logout request in the finally block to ensure it always runs


### PR DESCRIPTION
This PR fixes a bug in the `apiRequest` helper where `requestData` was being generated as a URL-encoded string but not actually used in the request.

**What was wrong:**
1. `Content-Length` was calculated based on the encoded string, causing a mismatch with the actual JSON body length;
2. This mismatch led to 406 responses from KlickTipp for some inputs.

**What changed:**
1. If the method is `POST/PUT` and `requestData` is generated, it is now correctly passed as the request body;
2. Headers now match the actual request format.